### PR TITLE
Fix compilation issue regarding @objc inference for Swift 4

### DIFF
--- a/SwiftMultiSelect/MultiSelectionTableView.swift
+++ b/SwiftMultiSelect/MultiSelectionTableView.swift
@@ -215,7 +215,7 @@ extension MultiSelecetionViewController:UITableViewDelegate,UITableViewDataSourc
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         self.searchString = searchText
         
-        if(searchText.characters.count<=0){
+        if (searchText.count <= 0 ) {
             self.perform(#selector(self.hideKeyboardWithSearchBar(_:)), with: searchBar, afterDelay: 0)
             self.searchString = ""
         }
@@ -225,7 +225,7 @@ extension MultiSelecetionViewController:UITableViewDelegate,UITableViewDataSourc
         self.tableView.reloadData()
     }
     
-    func hideKeyboardWithSearchBar(_ searchBar:UISearchBar){
+    @objc func hideKeyboardWithSearchBar(_ searchBar:UISearchBar){
         searchBar.resignFirstResponder()
     }
     

--- a/SwiftMultiSelect/MultiSelectionTableView.swift
+++ b/SwiftMultiSelect/MultiSelectionTableView.swift
@@ -215,7 +215,7 @@ extension MultiSelecetionViewController:UITableViewDelegate,UITableViewDataSourc
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         self.searchString = searchText
         
-        if (searchText.count <= 0 ) {
+        if(searchText.characters.count<=0){
             self.perform(#selector(self.hideKeyboardWithSearchBar(_:)), with: searchBar, afterDelay: 0)
             self.searchString = ""
         }


### PR DESCRIPTION
I was getting a compilation error something like this in Swift 4:

```
Argument of '#selector' refers to instance method 'hideKeyboardWithSearchBar(searchBar:)' that is not exposed to Objective-C
```

This should fix it.