### PR TITLE
Fix a compiler warning that resulted from using String.characters

### DIFF
--- a/SwiftMultiSelect/MultiSelectionTableView.swift
+++ b/SwiftMultiSelect/MultiSelectionTableView.swift
@@ -215,7 +215,7 @@ extension MultiSelecetionViewController:UITableViewDelegate,UITableViewDataSourc
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         self.searchString = searchText
         
-        if(searchText.characters.count<=0){
+        if (searchText.isEmpty) {
             self.perform(#selector(self.hideKeyboardWithSearchBar(_:)), with: searchBar, afterDelay: 0)
             self.searchString = ""
         }


### PR DESCRIPTION
'characters' has been depreciated in Swift 4. In this case, we can use `String.isEmpty` instead of `String.characters.count <= 0`